### PR TITLE
[#26] Update default web idle timeout to 30 minutes

### DIFF
--- a/hyte-runtime/src/main/filtered-resources/karaf/etc/org.ops4j.pax.web.cfg
+++ b/hyte-runtime/src/main/filtered-resources/karaf/etc/org.ops4j.pax.web.cfg
@@ -2,3 +2,5 @@ org.osgi.service.http.port=8888
 javax.servlet.context.tempdir=${karaf.data}/pax-web-jsp
 org.ops4j.pax.web.config.file=${karaf.etc}/jetty.xml
 org.apache.karaf.features.configKey = org.ops4j.pax.web
+org.ops4j.pax.web.session.timeout = 30
+


### PR DESCRIPTION
fix: #26 Update default web idle timeout to 30 minutes

fixes: #26 
