### PR TITLE
[HP-89] Exclude a karaf.util dep against 4.2.1-SNAPSHOT which isn't w…

### DIFF
--- a/repo/pom.xml
+++ b/repo/pom.xml
@@ -749,6 +749,12 @@
 			<groupId>org.apache.cxf.karaf</groupId>
 			<artifactId>cxf-karaf-commands</artifactId>
 			<version>${hyte.cxf.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.karaf</groupId>
+					<artifactId>org.apache.karaf.util</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.servicemix.specs</groupId>


### PR DESCRIPTION
…idel available anymore in Apache SNAPSHOTS repo

fix: 

fixes: #x, #y, ..
