### PR TITLE
[#131] Update to Karaf 4.2.8

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>io.hyte.platform</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.2.7.hyte-4274-SNAPSHOT</version>
+		<version>4.2.8.hyte-4280-SNAPSHOT</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>bom</artifactId>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.hyte.platform</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.2.7.hyte-4274-SNAPSHOT</version>
+		<version>4.2.8.hyte-4280-SNAPSHOT</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>features</artifactId>

--- a/hyte-db/pom.xml
+++ b/hyte-db/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.hyte.platform</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.2.7.hyte-4274-SNAPSHOT</version>
+		<version>4.2.8.hyte-4280-SNAPSHOT</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>hyte-db</artifactId>

--- a/hyte-db/src/main/resources/hyte-db-docker-assembly.xml
+++ b/hyte-db/src/main/resources/hyte-db-docker-assembly.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly
-	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
 	<id>docker</id>
 
 	<baseDirectory>/</baseDirectory>

--- a/hyte-db/src/main/resources/hyte-db-unix-assembly.xml
+++ b/hyte-db/src/main/resources/hyte-db-unix-assembly.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly
-	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
 	<id>unix</id>
 
 	<baseDirectory>/</baseDirectory>

--- a/hyte-db/src/main/resources/hyte-db-win64-assembly.xml
+++ b/hyte-db/src/main/resources/hyte-db-win64-assembly.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly
-	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
 	<id>win64</id>
 
 	<baseDirectory>/</baseDirectory>

--- a/hyte-mq/pom.xml
+++ b/hyte-mq/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.hyte.platform</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.2.7.hyte-4274-SNAPSHOT</version>
+		<version>4.2.8.hyte-4280-SNAPSHOT</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>hyte-mq</artifactId>

--- a/hyte-mq/src/main/resources/hyte-mq-docker-assembly.xml
+++ b/hyte-mq/src/main/resources/hyte-mq-docker-assembly.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly
-	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
 	<id>docker</id>
 
 	<baseDirectory>/</baseDirectory>

--- a/hyte-mq/src/main/resources/hyte-mq-unix-assembly.xml
+++ b/hyte-mq/src/main/resources/hyte-mq-unix-assembly.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly
-	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
 	<id>unix</id>
 
 	<baseDirectory>/</baseDirectory>

--- a/hyte-mq/src/main/resources/hyte-mq-win64-assembly.xml
+++ b/hyte-mq/src/main/resources/hyte-mq-win64-assembly.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly
-	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
 	<id>win64</id>
 
 	<baseDirectory>/</baseDirectory>

--- a/hyte-runtime/pom.xml
+++ b/hyte-runtime/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.hyte.platform</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.2.7.hyte-4274-SNAPSHOT</version>
+		<version>4.2.8.hyte-4280-SNAPSHOT</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>hyte-runtime</artifactId>

--- a/hyte-runtime/src/main/filtered-resources/karaf/etc/org.apache.karaf.management.cfg
+++ b/hyte-runtime/src/main/filtered-resources/karaf/etc/org.apache.karaf.management.cfg
@@ -4,9 +4,14 @@ rmiServerPort = 44444
 rmiServerHost = 0.0.0.0
 jmxRealm = karaf
 serviceUrl = service:jmx:rmi://${rmiServerHost}:${rmiServerPort}/jndi/rmi://${rmiRegistryHost}:${rmiRegistryPort}/karaf-${karaf.name}
+jmxmpEnabled = false
+jmxmpHost = 0.0.0.0
+jmxmpPort = 9999
+jmxmpServiceUrl = service:jmx:jmxmp://${jmxmpHost}:${jmxmpPort}
 daemon = true
 threaded = true
 objectName = connector:name=rmi
+jmxmpObjectName = connector:name=jmxmp
 #keyStoreAvailabilityTimeout = 5000
 #authenticatorType = password
 #secured = false
@@ -18,3 +23,4 @@ objectName = connector:name=rmi
 #createRmiRegistry = true
 #locateRmiRegistry = true
 #locateExistingMBeanServerIfPossible = true
+

--- a/hyte-runtime/src/main/filtered-resources/karaf/etc/org.apache.karaf.shell.cfg
+++ b/hyte-runtime/src/main/filtered-resources/karaf/etc/org.apache.karaf.shell.cfg
@@ -18,8 +18,8 @@ algorithm = RSA
 # 4: TRACE
 logLevel=1
 # welcomeBanner =
-# ciphers = aes128-ctr,arcfour128,aes128-cbc,3des-cbc,blowfish-cbc
-# macs = hmac-sha2-512,hmac-sha2-256,hmac-sha1
-# kexAlgorithms = diffie-hellman-group-exchange-sha256,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1
+ciphers = aes256-ctr,aes192-ctr,aes128-ctr
+macs =  hmac-sha2-512,hmac-sha2-256
+kexAlgorithms = ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
 # moduli-url = external moduli-url users wanna use
 completionMode = GLOBAL

--- a/hyte-runtime/src/main/filtered-resources/karaf/etc/org.ops4j.pax.url.mvn.cfg
+++ b/hyte-runtime/src/main/filtered-resources/karaf/etc/org.ops4j.pax.url.mvn.cfg
@@ -1,18 +1,19 @@
+#
+# see: https://ops4j1.jira.com/wiki/display/paxurl/Aether+Configuration
+#
 org.ops4j.pax.url.mvn.certificateCheck=true
 #org.ops4j.pax.url.mvn.settings=
 #org.ops4j.pax.url.mvn.localRepository=
 org.ops4j.pax.url.mvn.useFallbackRepositories=false
-#org.ops4j.pax.url.mvn.proxySupport=false
-#org.ops4j.pax.url.mvn.disableAether=true
 org.ops4j.pax.url.mvn.defaultRepositories=\
-    file:${karaf.home}/${karaf.default.repository}@id=system.repository@snapshots, \
-    file:${karaf.data}/kar@id=kar.repository@multi@snapshots, \
-    file:${karaf.base}/${karaf.default.repository}@id=child.system.repository@snapshots, \
+    ${karaf.home.uri}${karaf.default.repository}@id=system.repository@snapshots, \
+    ${karaf.data.uri}kar@id=kar.repository@multi@snapshots, \
+    ${karaf.base.uri}${karaf.default.repository}@id=child.system.repository@snapshots
     file:${karaf.home}/local-repo@snapshots@id=karaf.local-repo
 #org.ops4j.pax.url.mvn.defaultLocalRepoAsRemote = true
 org.ops4j.pax.url.mvn.repositories= \
     https://repo1.maven.org/maven2@id=central, \
-    http://repository.apache.org/content/groups/snapshots-group@id=apache@snapshots@noreleases, \
+    https://repository.apache.org/content/groups/snapshots-group@id=apache@snapshots@noreleases, \
     https://oss.sonatype.org/content/repositories/ops4j-snapshots@id=ops4j.sonatype.snapshots.deploy@snapshots@noreleases
 #org.ops4j.pax.url.mvn.globalUpdatePolicy = daily
 #org.ops4j.pax.url.mvn.globalChecksumPolicy = warn

--- a/hyte-runtime/src/main/filtered-resources/karaf/etc/startup.properties
+++ b/hyte-runtime/src/main/filtered-resources/karaf/etc/startup.properties
@@ -1,14 +1,14 @@
 # Bundles to be started on startup, with startlevel
-mvn\:org.apache.karaf.features/org.apache.karaf.features.extension/4.2.7 = 1
+mvn\:org.apache.karaf.features/org.apache.karaf.features.extension/4.2.8 = 1
+mvn\:org.apache.karaf.services/org.apache.karaf.services.eventadmin/4.2.8 = 5
+mvn\:org.ops4j.pax.url/pax-url-aether/2.6.2 = 5
 mvn\:org.apache.felix/org.apache.felix.metatype/1.2.2 = 5
-mvn\:org.apache.karaf.services/org.apache.karaf.services.eventadmin/4.2.7 = 5
-mvn\:org.ops4j.pax.url/pax-url-aether/2.6.1 = 5
-mvn\:org.fusesource.jansi/jansi/1.18 = 8
 mvn\:com.lmax/disruptor/${hyte.lmax.version} = 6
-mvn\:org.ops4j.pax.logging/pax-logging-api/1.11.2 = 8
-mvn\:org.ops4j.pax.logging/pax-logging-log4j2/1.11.2 = 8
-mvn\:org.ops4j.pax.logging/pax-logging-log4j2-extra/1.11.2 = 8
+mvn\:org.ops4j.pax.logging/pax-logging-api/1.11.4 = 8
+mvn\:org.fusesource.jansi/jansi/1.18 = 8
+mvn\:org.ops4j.pax.logging/pax-logging-log4j2/1.11.4 = 8
 mvn\:org.apache.felix/org.apache.felix.coordinator/1.0.2 = 9
 mvn\:org.apache.felix/org.apache.felix.configadmin/1.9.16 = 10
 mvn\:org.apache.felix/org.apache.felix.fileinstall/3.6.4 = 11
-mvn\:org.apache.karaf.features/org.apache.karaf.features.core/4.2.7 = 15
+mvn\:org.ops4j.pax.logging/pax-logging-log4j2-extra/1.11.4 = 12
+mvn\:org.apache.karaf.features/org.apache.karaf.features.core/4.2.8 = 15

--- a/hyte-runtime/src/main/resources/hyte-runtime-docker-assembly.xml
+++ b/hyte-runtime/src/main/resources/hyte-runtime-docker-assembly.xml
@@ -2,7 +2,7 @@
 <assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
 	<id>docker</id>
 
 	<baseDirectory>/</baseDirectory>

--- a/hyte-runtime/src/main/resources/hyte-runtime-unix-assembly.xml
+++ b/hyte-runtime/src/main/resources/hyte-runtime-unix-assembly.xml
@@ -2,7 +2,7 @@
 <assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
 	<id>unix</id>
 
 	<baseDirectory>/</baseDirectory>

--- a/hyte-runtime/src/main/resources/hyte-runtime-win64-assembly.xml
+++ b/hyte-runtime/src/main/resources/hyte-runtime-win64-assembly.xml
@@ -2,7 +2,7 @@
 <assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
 	<id>win64</id>
 
 	<baseDirectory>/</baseDirectory>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.hyte.platform</groupId>
 		<artifactId>build</artifactId>
-		<version>4.2.7.hyte-4274-SNAPSHOT</version>
+		<version>4.2.8.hyte-4280-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>parent</artifactId>
@@ -15,8 +15,8 @@
 		<hyte.activemq.version>5.15.10</hyte.activemq.version>
 		<hyte.camel.version>2.24.1</hyte.camel.version>
 		<hyte.cxf.version>3.3.3</hyte.cxf.version>
-		<hyte.jetty.version>9.4.20.v20190813</hyte.jetty.version>
-		<hyte.karaf.version>4.2.7</hyte.karaf.version>
+		<hyte.jetty.version>9.4.22.v20191022</hyte.jetty.version>
+		<hyte.karaf.version>4.2.8</hyte.karaf.version>
 		<hyte.spring.version>5.1.9.RELEASE_1</hyte.spring.version>
 		<hyte.h2.version>1.4.200</hyte.h2.version>
 		<!-- api and specs -->
@@ -27,19 +27,19 @@
 		<hyte.javax.servlet-api.version>3.1.0</hyte.javax.servlet-api.version>
 		<hyte.javax.websocket-api.version>1.1</hyte.javax.websocket-api.version>
 		<!-- pax versions -->
-		<hyte.pax-cdi.version>1.1.1</hyte.pax-cdi.version>
-		<hyte.pax-logging.version>1.11.2</hyte.pax-logging.version>
+		<hyte.pax-cdi.version>1.1.2</hyte.pax-cdi.version>
+		<hyte.pax-logging.version>1.11.4</hyte.pax-logging.version>
 		<hyte.pax-swissbox.version>1.8.3</hyte.pax-swissbox.version>
 		<hyte.pax-transx.version>0.4.4</hyte.pax-transx.version>
-		<hyte.pax.url.version>2.6.1</hyte.pax.url.version>
-		<hyte.pax.web.version>7.2.11</hyte.pax.web.version>
+		<hyte.pax.url.version>2.6.2</hyte.pax.url.version>
+		<hyte.pax.web.version>7.2.14</hyte.pax.web.version>
 		<!-- lib dependencies -->
-		<hyte.aries.spifly.dynamic.bundle.version>1.2</hyte.aries.spifly.dynamic.bundle.version>
+		<hyte.aries.spifly.dynamic.bundle.version>1.2.3</hyte.aries.spifly.dynamic.bundle.version>
 		<hyte.aries.transaction.blueprint_1.version>1.1.1</hyte.aries.transaction.blueprint_1.version>
 		<hyte.aries.transaction.blueprint_2.version>2.2.0</hyte.aries.transaction.blueprint_2.version>
 		<hyte.aries.transaction.manager.version>1.3.3</hyte.aries.transaction.manager.version>
 		<hyte.aries.util.version>1.1.3</hyte.aries.util.version>
-		<hyte.asm.version>7.1</hyte.asm.version>
+		<hyte.asm.version>7.2.0</hyte.asm.version>
 		<hyte.cdi-api.version>1.2</hyte.cdi-api.version>
 		<hyte.commons-codec.version>1.12</hyte.commons-codec.version>
 		<hyte.commons-collection.version>3.2.2</hyte.commons-collection.version>
@@ -80,6 +80,7 @@
 		<hyte.junit.version>4.11</hyte.junit.version>
 		<hyte.lmax.version>3.4.2</hyte.lmax.version>
 		<hyte.log4j.version>1.2.17</hyte.log4j.version>
+		<hyte.log4j2.version>2.13.0</hyte.log4j2.version>
 		<hyte.metrics-core.version>3.2.6</hyte.metrics-core.version>
 		<hyte.neethi.version>3.1.1</hyte.neethi.version>
 		<hyte.osgi.util.version>1.0.0</hyte.osgi.util.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>build</artifactId>
 	<name>HYTE :: Platform :: Build</name>
 	<packaging>pom</packaging>
-	<version>4.2.7.hyte-4274-SNAPSHOT</version>
+	<version>4.2.8.hyte-4280-SNAPSHOT</version>
 	<description>HYTE Platform</description>
 	<url>https://hyte.io</url>
 	<inceptionYear>2017</inceptionYear>

--- a/repo/pom.xml
+++ b/repo/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>io.hyte.platform</groupId>
 		<artifactId>parent</artifactId>
-		<version>4.2.7.hyte-4274-SNAPSHOT</version>
+		<version>4.2.8.hyte-4280-SNAPSHOT</version>
 		<relativePath>../parent/pom.xml</relativePath>
 	</parent>
 	<artifactId>repo</artifactId>
@@ -618,7 +618,6 @@
 		<dependency>
 			<groupId>org.apache.servicemix.bundles</groupId>
 			<artifactId>org.apache.servicemix.bundles.jaxb-runtime</artifactId>
-			<version>${hyte.smx.bundles.jaxb-runtime.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-pool</groupId>
@@ -895,7 +894,6 @@
 		<dependency>
 			<groupId>org.apache.servicemix.bundles</groupId>
 			<artifactId>org.apache.servicemix.bundles.jaxb-xjc</artifactId>
-			<version>${hyte.smx.bundles.jaxb-xjc.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.servicemix.bundles</groupId>

--- a/repo/src/main/filtered-resources/hyte-system/org/ops4j/pax/web/pax-web-features/7.2.14/pax-web-features-7.2.14-features.xml
+++ b/repo/src/main/filtered-resources/hyte-system/org/ops4j/pax/web/pax-web-features/7.2.14/pax-web-features-7.2.14-features.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- 
+
+	<!-- 
 	
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
@@ -14,61 +15,62 @@
 	limitations under the License.
 	
 	 -->
-<features name="org.ops4j.pax.web-7.2.11" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0">
 
-    <feature name="pax-web-core" description="Provide Core pax-web bundles" version="7.2.11">
-        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-api/7.2.11</bundle>
-        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-spi/7.2.11</bundle>
+<features name="org.ops4j.pax.web-7.2.14" xmlns="http://karaf.apache.org/xmlns/features/v1.3.0">
 
-        <bundle dependency="true">mvn:org.ow2.asm/asm/7.1</bundle>
-        <bundle dependency="true">mvn:org.ow2.asm/asm-util/7.1</bundle>
-        <bundle dependency="true">mvn:org.ow2.asm/asm-tree/7.1</bundle>
-        <bundle dependency="true">mvn:org.ow2.asm/asm-analysis/7.1</bundle>
-        <bundle dependency="true">mvn:org.ow2.asm/asm-commons/7.1</bundle>
+    <feature name="pax-web-core" description="Provide Core pax-web bundles" version="7.2.14">
+        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-api/7.2.14</bundle>
+        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-spi/7.2.14</bundle>
+
+        <bundle dependency="true">mvn:org.ow2.asm/asm/7.2</bundle>
+        <bundle dependency="true">mvn:org.ow2.asm/asm-util/7.2</bundle>
+        <bundle dependency="true">mvn:org.ow2.asm/asm-tree/7.2</bundle>
+        <bundle dependency="true">mvn:org.ow2.asm/asm-analysis/7.2</bundle>
+        <bundle dependency="true">mvn:org.ow2.asm/asm-commons/7.2</bundle>
 
         <bundle dependency="true">mvn:org.apache.xbean/xbean-bundleutils/4.14</bundle>
         <bundle dependency="true">mvn:org.apache.xbean/xbean-reflect/4.14</bundle>
         <bundle dependency="true">mvn:org.apache.xbean/xbean-finder/4.14</bundle>
     </feature>
 
-    <feature name="pax-jetty" description="Provide Jetty engine support" version="9.4.20.v20190813">
+    <feature name="pax-jetty" description="Provide Jetty engine support" version="9.4.22.v20191022">
         <bundle dependency="true" start-level="30">mvn:org.apache.servicemix.specs/org.apache.servicemix.specs.activation-api-1.1/2.9.0</bundle>
         <bundle dependency="true" start-level="30">mvn:javax.servlet/javax.servlet-api/3.1.0</bundle>
 		<bundle dependency="true" start-level="30">mvn:com.sun.mail/javax.mail/${hyte.javax.mail-api.version}</bundle>
         <bundle dependency="true" start-level="30">mvn:org.apache.geronimo.specs/geronimo-jta_1.1_spec/1.1.1</bundle>
-        <bundle dependency="true" start-level="30">mvn:javax.annotation/javax.annotation-api/${hyte.javax.annotation-api.version}</bundle>
+        <bundle dependency="true" start-level="30">mvn:javax.annotation/javax.annotation-api/1.3</bundle>
         <bundle dependency="true" start-level="30">mvn:org.apache.geronimo.specs/geronimo-jaspic_1.0_spec/1.1</bundle>
-        <bundle dependency="true" start-level="30">mvn:org.apache.aries.spifly/org.apache.aries.spifly.dynamic.bundle/1.2</bundle>
+        <bundle dependency="true" start-level="30">mvn:org.apache.aries.spifly/org.apache.aries.spifly.dynamic.bundle/1.2.3</bundle>
         <bundle dependency="true" start-level="30">mvn:org.apache.aries/org.apache.aries.util/1.1.3</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-continuation/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-http/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-io/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-jaspi/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-plus/9.4.20.v20190813</bundle>
-       	<bundle start-level="30">mvn:org.eclipse.jetty/jetty-jndi/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-rewrite/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-security/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-server/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-servlet/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-servlets/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-util/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-util-ajax/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-webapp/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-jaas/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-xml/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-client/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-deploy/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-jmx/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-proxy/9.4.20.v20190813</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-continuation/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-http/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-io/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-jaspi/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-plus/9.4.22.v20191022</bundle>
+       	<bundle start-level="30">mvn:org.eclipse.jetty/jetty-jndi/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-rewrite/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-security/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-server/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-servlet/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-servlets/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-util/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-util-ajax/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-webapp/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-jaas/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-xml/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-client/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-deploy/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-jmx/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-proxy/9.4.22.v20191022</bundle>
         <conditional>
         	<condition>pax-http-whiteboard</condition>
-	        <bundle start-level="30">mvn:org.eclipse.jetty.websocket/websocket-server/9.4.20.v20190813</bundle>
-	        <bundle start-level="30">mvn:org.eclipse.jetty.websocket/websocket-client/9.4.20.v20190813</bundle>
-	        <bundle start-level="30">mvn:org.eclipse.jetty.websocket/websocket-common/9.4.20.v20190813</bundle>
-	        <bundle start-level="30">mvn:org.eclipse.jetty.websocket/websocket-servlet/9.4.20.v20190813</bundle>
-	        <bundle start-level="30">mvn:org.eclipse.jetty.websocket/websocket-api/9.4.20.v20190813</bundle>
-	        <bundle start-level="30">mvn:org.eclipse.jetty.websocket/javax-websocket-server-impl/9.4.20.v20190813</bundle>
-	        <bundle start-level="30">mvn:org.eclipse.jetty.websocket/javax-websocket-client-impl/9.4.20.v20190813</bundle>
+	        <bundle start-level="30">mvn:org.eclipse.jetty.websocket/websocket-server/9.4.22.v20191022</bundle>
+	        <bundle start-level="30">mvn:org.eclipse.jetty.websocket/websocket-client/9.4.22.v20191022</bundle>
+	        <bundle start-level="30">mvn:org.eclipse.jetty.websocket/websocket-common/9.4.22.v20191022</bundle>
+	        <bundle start-level="30">mvn:org.eclipse.jetty.websocket/websocket-servlet/9.4.22.v20191022</bundle>
+	        <bundle start-level="30">mvn:org.eclipse.jetty.websocket/websocket-api/9.4.22.v20191022</bundle>
+	        <bundle start-level="30">mvn:org.eclipse.jetty.websocket/javax-websocket-server-impl/9.4.22.v20191022</bundle>
+	        <bundle start-level="30">mvn:org.eclipse.jetty.websocket/javax-websocket-client-impl/9.4.22.v20191022</bundle>
 	        <bundle start-level="30">mvn:javax.websocket/javax.websocket-api/1.1</bundle>
         </conditional>
 
@@ -78,7 +80,7 @@
         </capability>
     </feature>
 
-    <feature name="pax-jetty-http2" version="7.2.11" description="Optional additional feature to run Jetty with SPDY">
+    <feature name="pax-jetty-http2" version="7.2.14" description="Optional additional feature to run Jetty with SPDY">
     	<details>
     		Please beware, for this feature to run properly you'll need to add the alpn-boot.jar to the
     		lib/ext folder of Karaf in some cases of your JVM.
@@ -90,16 +92,16 @@
     	</details>
         <library type="extension">mvn:org.mortbay.jetty.alpn/alpn-boot/8.1.4.v20150727</library>
         <feature version="[9.3,10.0)">pax-jetty</feature>
-		<bundle start-level="1">mvn:org.eclipse.jetty.osgi/jetty-osgi-alpn/9.4.20.v20190813</bundle>
+		<bundle start-level="1">mvn:org.eclipse.jetty.osgi/jetty-osgi-alpn/9.4.22.v20191022</bundle>
 		<bundle start-level="30">mvn:org.eclipse.jetty.alpn/alpn-api/1.1.2.v20150522</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-alpn-server/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty.http2/http2-server/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty.http2/http2-common/9.4.20.v20190813</bundle>
-        <bundle start-level="30">mvn:org.eclipse.jetty.http2/http2-hpack/9.4.20.v20190813</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty/jetty-alpn-server/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty.http2/http2-server/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty.http2/http2-common/9.4.22.v20191022</bundle>
+        <bundle start-level="30">mvn:org.eclipse.jetty.http2/http2-hpack/9.4.22.v20191022</bundle>
     </feature>
 
-    <feature name="pax-http-jetty" version="7.2.11">
-        <configfile finalname="${karaf.etc}/jetty.xml">mvn:org.ops4j.pax.web/pax-web-features/7.2.11/xml/jettyconfig</configfile>
+    <feature name="pax-http-jetty" version="7.2.14">
+        <configfile finalname="${karaf.etc}/jetty.xml">mvn:org.ops4j.pax.web/pax-web-features/7.2.14/xml/jettyconfig</configfile>
         <config name="org.ops4j.pax.web">
             org.osgi.service.http.port=8181
             javax.servlet.context.tempdir=${karaf.data}/pax-web-jsp
@@ -109,8 +111,8 @@
         <feature version="[9.3,10.0)">pax-jetty</feature>
 
         <feature>pax-web-core</feature>
-        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-runtime/7.2.11</bundle>
-        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-jetty/7.2.11</bundle>
+        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-runtime/7.2.14</bundle>
+        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-jetty/7.2.14</bundle>
 
         <capability>
             pax.http.provider;provider:=jetty
@@ -122,7 +124,7 @@
         </conditional>
     </feature>
 
-    <feature name="pax-http" version="7.2.11" description="Implementation of the OSGI HTTP Service">
+    <feature name="pax-http" version="7.2.14" description="Implementation of the OSGI HTTP Service">
         <details>Allows to publish servlets using pax web and jetty</details>
         <feature dependency="true" version="[7.2,7.3)">pax-http-jetty</feature>
         <requirement>
@@ -130,12 +132,12 @@
         </requirement>
     </feature>
 
-    <feature name="pax-http-whiteboard" description="Provide HTTP Whiteboard pattern support" version="7.2.11">
+    <feature name="pax-http-whiteboard" description="Provide HTTP Whiteboard pattern support" version="7.2.14">
         <feature version="[7.2,7.3)">pax-http</feature>
         <bundle dependency="true" start-level="30">mvn:org.eclipse.jdt.core.compiler/ecj/4.5.1</bundle>
         <bundle start-level="30" dependency="true">mvn:javax.el/javax.el-api/3.0.0</bundle>
-        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-jsp/7.2.11</bundle>
-        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-extender-whiteboard/7.2.11</bundle>
+        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-jsp/7.2.14</bundle>
+        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-extender-whiteboard/7.2.14</bundle>
 
         <capability>
             osgi.contract;osgi.contract=JavaEl;version:Version="3";uses:="javax.el",
@@ -144,19 +146,19 @@
         </capability>
     </feature>
 
-    <feature name="pax-war" description="Provide support of a full WebContainer" version="7.2.11">
+    <feature name="pax-war" description="Provide support of a full WebContainer" version="7.2.14">
         <config name="org.ops4j.pax.url.war">
             org.ops4j.pax.url.war.importPaxLoggingPackages=true
         </config>
         <feature version="[7.2,7.3)">pax-http-whiteboard</feature>
-        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-descriptor/7.2.11</bundle>
-        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-extender-war/7.2.11</bundle>
-        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-extender-whiteboard/7.2.11</bundle>
-        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-deployer/7.2.11</bundle>
+        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-descriptor/7.2.14</bundle>
+        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-extender-war/7.2.14</bundle>
+        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-extender-whiteboard/7.2.14</bundle>
+        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-deployer/7.2.14</bundle>
         <bundle start-level="30">mvn:org.ops4j.pax.url/pax-url-war/2.6.1/jar/uber</bundle>
     </feature>
 
-    <feature name="pax-http-tomcat" description="Provide Tomcat support" version="7.2.11">
+    <feature name="pax-http-tomcat" description="Provide Tomcat support" version="7.2.14">
         <config name="org.ops4j.pax.url.war">
             org.ops4j.pax.url.war.importPaxLoggingPackages=true
         </config>
@@ -195,9 +197,9 @@
         <bundle dependency="true" start-level="30">mvn:javax.websocket/javax.websocket-api/1.1</bundle>
 
         <feature>pax-web-core</feature>
-        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-runtime/7.2.11</bundle>
-        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-tomcat/7.2.11</bundle>
-        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-jsp/7.2.11</bundle>
+        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-runtime/7.2.14</bundle>
+        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-tomcat/7.2.14</bundle>
+        <bundle start-level="30">mvn:org.ops4j.pax.web/pax-web-jsp/7.2.14</bundle>
 
         <capability>
             pax.http.provider;provider:=tomcat
@@ -211,12 +213,12 @@
         </conditional>
     </feature>
 
-    <feature name="pax-war-tomcat" version="7.2.11">
+    <feature name="pax-war-tomcat" version="7.2.14">
         <feature version="[7.2,7.3)">pax-http-tomcat</feature>
         <feature version="[7.2,7.3)">pax-war</feature>
     </feature>
 
-    <feature name="pax-jsf-support" version="7.2.11">
+    <feature name="pax-jsf-support" version="7.2.14">
         <feature version="[7.2,7.3)">pax-war</feature>
         <bundle dependency="true">mvn:javax.enterprise/cdi-api/1.2</bundle>
         <bundle dependency="true">mvn:org.apache.servicemix.bundles/org.apache.servicemix.bundles.javax-inject/1_2</bundle>
@@ -236,10 +238,10 @@
         </capability>
     </feature>
 
-    <feature name="pax-jsf-resources-support" description="Provide sharing of resources according to Servlet 3.0 for OSGi bundles and JSF" version="7.2.11">
+    <feature name="pax-jsf-resources-support" description="Provide sharing of resources according to Servlet 3.0 for OSGi bundles and JSF" version="7.2.14">
         <feature version="[7.2,7.3)">pax-jsf-support</feature>
-        <bundle dependency="true">mvn:org.ops4j.pax.web/pax-web-resources-extender/7.2.11</bundle>
-        <bundle>mvn:org.ops4j.pax.web/pax-web-resources-jsf/7.2.11</bundle>
+        <bundle dependency="true">mvn:org.ops4j.pax.web/pax-web-resources-extender/7.2.14</bundle>
+        <bundle>mvn:org.ops4j.pax.web/pax-web-resources-jsf/7.2.14</bundle>
     </feature>
 
     <feature name="undertow" version="1.4.23.Final">
@@ -259,9 +261,9 @@
         </capability>
     </feature>
 
-    <feature name="pax-http-undertow" version="7.2.11">
-        <configfile finalname="${karaf.etc}/undertow.properties">mvn:org.ops4j.pax.web/pax-web-features/7.2.11/properties/undertowconfig</configfile>
-        <configfile finalname="${karaf.etc}/undertow.xml">mvn:org.ops4j.pax.web/pax-web-features/7.2.11/xml/undertowconfig</configfile>
+    <feature name="pax-http-undertow" version="7.2.14">
+        <configfile finalname="${karaf.etc}/undertow.properties">mvn:org.ops4j.pax.web/pax-web-features/7.2.14/properties/undertowconfig</configfile>
+        <configfile finalname="${karaf.etc}/undertow.xml">mvn:org.ops4j.pax.web/pax-web-features/7.2.14/xml/undertowconfig</configfile>
         <config name="org.ops4j.pax.web">
             org.osgi.service.http.port=8181
             javax.servlet.context.tempdir=${karaf.data}/pax-web-jsp
@@ -273,8 +275,8 @@
         <feature version="[7.2,7.3)">pax-http</feature>
 
         <feature>pax-web-core</feature>
-        <bundle>mvn:org.ops4j.pax.web/pax-web-runtime/7.2.11</bundle>
-        <bundle>mvn:org.ops4j.pax.web/pax-web-undertow/7.2.11</bundle>
+        <bundle>mvn:org.ops4j.pax.web/pax-web-runtime/7.2.14</bundle>
+        <bundle>mvn:org.ops4j.pax.web/pax-web-undertow/7.2.14</bundle>
 
         <capability>
             pax.http.provider;provider:=undertow

--- a/repo/src/main/resources/hyte-runtime-repo-assembly.xml
+++ b/repo/src/main/resources/hyte-runtime-repo-assembly.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly
-	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
 	<id>repo</id>
 
 	<baseDirectory>/</baseDirectory>
@@ -14,7 +14,7 @@
 	<fileSets>
 		<fileSet>
 			<directory>${project.build.directory}/hyte-repo</directory>
-			<outputDirectory>/</outputDirectory>
+			<outputDirectory></outputDirectory>
 			<filtered>false</filtered>
 			<excludes>
 				<exclude>.locks</exclude>
@@ -25,7 +25,7 @@
 		</fileSet>
 		<fileSet>
 			<directory>${project.build.directory}/local-repo</directory>
-			<outputDirectory>/</outputDirectory>
+			<outputDirectory></outputDirectory>
 			<excludes>
 				<!-- TODO: Consider excluding *.pom from local-repo -->
 				<exclude>.locks</exclude>

--- a/repo/src/main/resources/hyte-runtime-system-assembly.xml
+++ b/repo/src/main/resources/hyte-runtime-system-assembly.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <assembly
-	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2"
+	xmlns="http://maven.apache.org/ASSEMBLY/2.1.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+	xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 http://maven.apache.org/xsd/assembly-2.1.0.xsd">
 	<id>system</id>
 
 	<baseDirectory>/</baseDirectory>
@@ -14,7 +14,7 @@
 	<fileSets>
 		<fileSet>
 			<directory>${project.build.directory}/hyte-system</directory>
-			<outputDirectory>/</outputDirectory>
+			<outputDirectory></outputDirectory>
 			<filtered>false</filtered>
 			<excludes>
 				<exclude>.locks</exclude>


### PR DESCRIPTION
 - Upgrade dependencies for Karaf 4.2.8
 - Update Assembly descriptors to 2.1.0
 - Bump revision to 4.2.8.hyte-4280

fixes: #131

