### PR TITLE
[#158] Remove examples/ folder from hyte-mq win64 packaging

### DIFF
--- a/hyte-mq/src/main/resources/hyte-mq-win64-assembly.xml
+++ b/hyte-mq/src/main/resources/hyte-mq-win64-assembly.xml
@@ -42,6 +42,7 @@
 				<exclude>bin/shell</exclude>
 				<exclude>bin/status</exclude>
 				<exclude>bin/instance</exclude>
+				<exclude>**/examples/**</exclude>
 				<exclude>**/maven-metadata-local.xml</exclude>
 				<exclude>**/_remote.repositories</exclude>
 			</excludes>


### PR DESCRIPTION
Notes: 

fixes: #158 
