### PR TITLE
[#304] Fix jetty.xml for GzipHandler with 9.4.53.v20231009

### DIFF
--- a/hyte-runtime/src/main/filtered-resources/karaf/etc/jetty.xml
+++ b/hyte-runtime/src/main/filtered-resources/karaf/etc/jetty.xml
@@ -48,11 +48,11 @@
         </Arg>
     </Call>
     <Get id="OrigHandler" name="handler"/>
-	<Set name="handler">
-		<New id="GzipHandler" class="org.eclipse.jetty.server.handler.gzip.GzipHandler">
+    <Set name="handler">
+        <New id="GzipHandler" class="org.eclipse.jetty.server.handler.gzip.GzipHandler">
             <Set name="handler">
-			    <Ref id="OrigHandler"/>
-		    </Set>
-	    </New>
+                <Ref refid="OrigHandler"/>
+	    </Set>
+	</New>
     </Set>
 </Configure>


### PR DESCRIPTION
Notes: 

fixes: #304
